### PR TITLE
reference orbit in SCBBA

### DIFF
--- a/SCBBA.m
+++ b/SCBBA.m
@@ -311,7 +311,7 @@ end
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Data measurement
 function [BPMpos,tmpTra] = dataMeasurement(SC,mOrd,BPMind,jBPM,nDim,par,varargin)
-	% This function performs the data measruement by looping through the magnet
+	% This function performs the data measurement by looping through the magnet
 	% setpoints and changing either the injected beam trajectory or the CMs to create 
 	% a local orbit bump.
 	%

--- a/SCBBA.m
+++ b/SCBBA.m
@@ -258,7 +258,7 @@ function [SC,errorFlags] = SCBBA(SC,BPMords,magOrds,varargin)
 					% Get orbit bump at BBA BPM
 					[CMords,CMvec] = getOrbitBump(SC,mOrd,BPMords(nDim,jBPM),nDim,par);
 					
-					% Perform data measrurment
+					% Perform data measurement
 					[BPMpos,tmpTra] = dataMeasurement(SC,mOrd,BPMind,jBPM,nDim,par,CMords,CMvec);
 
 				case 'TBT'

--- a/SCBBA.m
+++ b/SCBBA.m
@@ -734,8 +734,8 @@ end
 % Get orbit bump
 function [CMords,CMvec] = getOrbitBump(SC,mOrd,BPMord,nDim,par)
 	% This function is used to create a pseudo orbit bump by running orbit feedback on the actual 
-	% machine with target 
-	% of zero except at the BBA-BPM (here the target is 'par.BBABPMtarget'). The weights 
+	% machine with target of the closed orbit BPM readings
+	% except at the BBA-BPM (here the target is 'par.BBABPMtarget'). The weights
 	% at the BPMs upstream and downstream the BBA BPM as defined by 'par.orbBumpWindow' are set to 
 	% zero in order to give some slack.
 	% Note that this could also be done by creating a 'real' orbit bump using 3 CMs, however we
@@ -767,9 +767,9 @@ function [CMords,CMvec] = getOrbitBump(SC,mOrd,BPMord,nDim,par)
 	% Get actual index-ordinate pairing of BBA BPM and orbit feedback BPMs
 	tmpBPMind = find(BPMord==par.RMstruct.BPMords);
 		
-	% Define reference orbit (zero everywhere except at BBA BPM)
-	R0 = zeros(2,length(par.RMstruct.BPMords));
-	R0(nDim,tmpBPMind) = par.BBABPMtarget;
+	% Define reference orbit (closed orbit BPM readings except at BBA BPM)
+	R0 = SCgetBPMreading(SC);
+	R0(nDim,tmpBPMind) = R0(nDim,tmpBPMind) + par.BBABPMtarget;
 	
 	% Define BPM weighting factors (empirically found to work sufficiently well)
 	W0 = ones(2,length(par.RMstruct.BPMords));


### PR DESCRIPTION
Dear Thorsten,

the changes here below are very important and are for your consideration. 

The bump calculated inside the routine getOrbitBump in SCBBA used zeros as reference. The problem with this method is that the orbit gets corrected to zeros when applying the CMvec values.

Instead, the reference orbit should be the closed orbit read by the BPMs, and the BBABPMtarget value should be added to it.
This allows to calculate a set of correctors that preserves the closed orbit within the BPM errors including the desired offset at the target BPM.

I reported it early last year in this issue :
https://github.com/ThorstenHellert/SC/issues/22

Best regards,
o