### PR TITLE
get LOCO RINGData when SC.ORD.Cavity has more than one index

### DIFF
--- a/SClocoLib.m
+++ b/SClocoLib.m
@@ -495,8 +495,8 @@ function varargout = SClocoLib(funName,varargin)
 	function setupLOCOmodel(SC,varargin)
 
 		% Create LOCO model from ideal ring
-		RINGdata.CavityFrequency   = SC.IDEALRING{SC.ORD.Cavity}.Frequency;
-		RINGdata.CavityHarmNumber  = SC.IDEALRING{SC.ORD.Cavity}.HarmNumber;
+		RINGdata.CavityFrequency   = mean(atgetfieldvalues(SC.IDEALRING,SC.ORD.Cavity,'Frequency'));
+		RINGdata.CavityHarmNumber  = round(mean(atgetfieldvalues(SC.IDEALRING,SC.ORD.Cavity,'HarmNumber')));
 		RINGdata.Lattice           = SC.IDEALRING;
 		
 		% Calculate disturbed lattice properties and save initial machine state

--- a/SCsynchEnergyCorrection.m
+++ b/SCsynchEnergyCorrection.m
@@ -208,13 +208,17 @@ function inputCheck(SC,par)
 	end
 	if par.minTurns>=par.nTurns
 		error('Minimum number of turns (%d) must be smaller than overal number of turns (%d).', par.minTurns,par.nTurns)
-	end
-	if ~isfield(SC.RING{par.cavOrd},'Frequency')
-		error('This is not a cavity (ord: %d)',par.cavOrd)
-	end
-	if ~any(strcmp(SC.RING{par.cavOrd}.PassMethod,{'CavityPass','RFCavityPass'}))
-		warning('Cavity (ord: %d) seemed to be switched off.',par.cavOrd)
-	end
+    end
+    for cavOrd = par.cavOrd
+	    if ~isfield(SC.RING{cavOrd},'Frequency')
+		    error('This is not a cavity (ord: %d)',par.cavOrd)
+        end
+    end
+    for cavOrd = par.cavOrd
+	    if ~any(strcmp(SC.RING{cavOrd}.PassMethod,{'CavityPass','RFCavityPass'}))
+		    warning('Cavity (ord: %d) seemed to be switched off.',cavOrd)
+        end
+    end
 end
 
 % Calculate mean turn-by-turn horizontal BPM shift

--- a/SCsynchPhaseCorrection.m
+++ b/SCsynchPhaseCorrection.m
@@ -100,7 +100,8 @@ function [deltaPhi,ERROR] = SCsynchPhaseCorrection(SC,varargin)
 	BPMshift = nan(1,par.nSteps);
 
 	% RF wavelength [m]
-	lambda = 299792458/SC.RING{par.cavOrd}.Frequency;
+    meanfreq = mean(atgetfieldvalues(SC.IDEALRING,par.cavOrd,'Frequency'));
+    lambda = 299792458/meanfreq;
 
 	% Define phase scan range
 	lambdaTestVec = 1/2 * lambda * linspace(-1,1,par.nSteps);
@@ -242,13 +243,17 @@ function inputCheck(SC,par)
 	end
 	if par.nSteps<2 || par.nTurns<2
 		error('Number of steps and number of turns must be larger than 2.')
-	end
-	if ~isfield(SC.RING{par.cavOrd},'Frequency')
-		error('This is not a cavity (ord: %d)',par.cavOrd)
-	end
-	if ~any(strcmp(SC.RING{par.cavOrd}.PassMethod,{'CavityPass','RFCavityPass'}))
-		warning('Cavity (ord: %d) seemed to be switched off.',par.cavOrd)
-	end
+    end
+    for cavOrd = par.cavOrd
+	    if ~isfield(SC.RING{cavOrd},'Frequency')
+		    error('This is not a cavity (ord: %d)',cavOrd)
+        end
+    end
+    for cavOrd = par.cavOrd
+	    if ~any(strcmp(SC.RING{cavOrd}.PassMethod,{'CavityPass','RFCavityPass'}))
+		    warning('Cavity (ord: %d) seemed to be switched off.',cavOrd)
+        end
+    end
 end
 % Calculate mean turn-by-turn horizontal BPM shift
 function [BPMshift,dE] = getTbTEnergyShift(SC,par)

--- a/SCupdateMagnets.m
+++ b/SCupdateMagnets.m
@@ -142,7 +142,7 @@ function SC = updateMagnets(SC,source,target)
 		SC.RING{target}.PolynomB(1) = SC.RING{target}.PolynomB(1) + SC.RING{source}.BendingAngleError * SC.RING{target}.BendingAngle/SC.RING{target}.Length;
 	end
 
-	% Include bending angle error from combinded function magnets
+	% Include bending angle error from combined function magnets
 	if isfield(SC.RING{source},'BendingAngle')
 		% Check if magnet is registered as combined function (bending angle depends on quad component)
 		if isfield(SC.RING{source},'CombinedFunction') && SC.RING{source}.CombinedFunction==1


### PR DESCRIPTION
Dear all,
this merge request works around a limitation in the construction of the loco structure RINGData.

It failed when SC.ORD.Cavity has more than one index.

These modifications propose to get the frequency as the mean value of the cavities frequency in SC.ORD.Cavity.
The same is done for the harmonic number but the result is rounded to the nearest integer.

Best regards,
o

P.S.
There is also a small typo fix included in this merge.